### PR TITLE
Fix broadcast wrong messages

### DIFF
--- a/src/redis.js
+++ b/src/redis.js
@@ -21,7 +21,7 @@ module.exports = function(config) {
           debug('subscribing to handler %s', ev);
           service.sub.subscribe(ev);
           service.sub.on('message', function(e, data) {
-            if (e != ev) {
+            if (e !== ev) {
               return;
             }
             

--- a/src/redis.js
+++ b/src/redis.js
@@ -21,8 +21,12 @@ module.exports = function(config) {
           debug('subscribing to handler %s', ev);
           service.sub.subscribe(ev);
           service.sub.on('message', function(e, data) {
+            if (e != ev) {
+              return;
+            }
+            
             data = JSON.parse(data);
-            debug('got event, calling old emit %s', data);
+            debug('got event "%s", calling old emit %s', e, data);
             service._emit.call(service, event, data);
           });
         });


### PR DESCRIPTION
The on('message') is fired for every match. We should only broadcast it, if the path and event match.

With DEBUG=* node src/

Before:
```
feathers-sync:redis emitting event to channel todos patched +2ms
feathers-sync:redis got event "todos patched", calling old emit [object Object] +1ms
feathers-sync:redis got event "todos patched", calling old emit [object Object] +0ms
feathers-sync:redis got event "todos patched", calling old emit [object Object] +0ms
feathers-sync:redis got event "todos patched", calling old emit [object Object] +1ms
```

After:
```
feathers-sync:redis emitting event to channel todos patched +3ms
feathers-sync:redis got event "todos patched", calling old emit [object Object] +0ms
```