### PR TITLE
Mubsub config option fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "amqplib": "^0.5.0",
     "debug": "^2.3.0",
+    "lodash": "^4.17.4",
     "mubsub": "^1.0.4",
     "redis": "^2.4.2"
   },

--- a/src/mongodb.js
+++ b/src/mongodb.js
@@ -1,17 +1,11 @@
 var mubsub = require('mubsub');
 var debug = require('debug')('feathers-sync');
+var omit = require('lodash').omit;
 
 module.exports = function (config) {
   debug('setting up database %s', config.db);
-  var collection = config.collection || 'events';
   var client = mubsub(config.db);
-
-  // Delete non-valid mubsub config options, causes a crash if
-  // these keys are present.
-  delete config.db;
-  delete config.collection;
-
-  var channel = client.channel(collection, config);
+  var channel = client.channel(config.collection || 'events', omit(config, ['db', 'collection']));
 
   return function () {
     var oldSetup = this.setup;

--- a/src/mongodb.js
+++ b/src/mongodb.js
@@ -3,9 +3,15 @@ var debug = require('debug')('feathers-sync');
 
 module.exports = function (config) {
   debug('setting up database %s', config.db);
-
+  var collection = config.collection || 'events';
   var client = mubsub(config.db);
-  var channel = client.channel(config.collection || 'events', config);
+
+  // Delete non-valid mubsub config options, causes a crash if
+  // these keys are present.
+  delete config.db;
+  delete config.collection;
+
+  var channel = client.channel(collection, config);
 
   return function () {
     var oldSetup = this.setup;


### PR DESCRIPTION
I noticed a bug with mongodb using this application setup:

```javascript
app
  .configure(configuration(path.join(__dirname, '..')))
  .use(compress())
  .options('*', cors())
  .use(cors())
  .use(bodyParser.json())
  .use(bodyParser.urlencoded({ extended: true }))
  .configure(hooks())
  .configure(rest())
  .configure(socketio())
  .configure(sync({
    db: 'mongodb://localhost:27017/sync',
    collection: 'events'
  }))
  .configure(services)
  .configure(jwt())
  .configure(oauth2({
    name: 'facebook-token',
    Strategy: FacebookTokenStrategy
  }))
  .configure(oauth1({
    name: 'twitter-token',
    Strategy: TwitterTokenStrategy
  }))
  .configure(middleware);
```

On startup, an error was being thrown:

`MongoError: The field 'db' is not a valid collection option. Options: { db: "mongodb://localhost:27017/sync", collection: "events", capped: true, size: 5242880 }`

The error stems from mubsub, which only takes four config options passed to `client.channel`: `size`, `max`, `retryInterval`, and `recreate`. The solution is simple, delete `config.db` and `config.collection` after using them.